### PR TITLE
Fix 500 Internal Server Error for /api/historical-accuracy endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -147,7 +147,7 @@ async def get_hourly_distribution():
         raise HTTPException(status_code=500, detail=str(e))
 
 class HistoricalAccuracyResponse(BaseModel):
-    date: str
+    timestamp: str
     accuracy: float
 
 @app.get("/api/historical-accuracy", response_model=List[HistoricalAccuracyResponse])
@@ -155,7 +155,7 @@ async def get_historical_accuracy():
     try:
         # Assuming we have a function to get historical accuracy
         historical_data = traffic_analyzer.get_historical_accuracy()
-        return [HistoricalAccuracyResponse(date=date, accuracy=accuracy) for date, accuracy in historical_data.items()]
+        return [HistoricalAccuracyResponse(timestamp=timestamp, accuracy=accuracy) for timestamp, accuracy in historical_data.items()]
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/ml/trafficanalysis/trafficanalysis.py
+++ b/backend/ml/trafficanalysis/trafficanalysis.py
@@ -104,5 +104,5 @@ class TrafficAnalyzer:
             raise FileNotFoundError(f"Traffic data file not found at: {data_path}")
 
         df = pd.read_csv(data_path)
-        historical_data = df.groupby('date')['congestion_level'].mean().to_dict()
+        historical_data = df.groupby('timestamp')['congestion_level'].mean().to_dict()
         return historical_data


### PR DESCRIPTION
Fix the 500 Internal Server Error for the `/api/historical-accuracy` endpoint.

* **backend/ml/trafficanalysis/trafficanalysis.py**
  - Update the `get_historical_accuracy` method to group data by the 'timestamp' column instead of the non-existent 'date' column.

* **backend/main.py**
  - Update the `HistoricalAccuracyResponse` model to use 'timestamp' instead of 'date'.
  - Update the `get_historical_accuracy` function to correctly retrieve historical accuracy data and return it using the updated model.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kasinadhsarma/urbandevlopment/pull/4?shareId=6808753c-8ba4-4bad-9f55-dc977442fffd).